### PR TITLE
Add `SubmoduleRequest::satisfies_property_type`

### DIFF
--- a/include/pluginplay/submodule_request.hpp
+++ b/include/pluginplay/submodule_request.hpp
@@ -53,7 +53,7 @@ public:
     using submod_uuid_map = typename Module::submod_uuid_map;
 
     /// Type used for RTTI
-    using rtti_type = std::type_index;
+    using rtti_type = type::rtti;
 
     /** @brief Makes an empty request.
      *

--- a/include/pluginplay/submodule_request.hpp
+++ b/include/pluginplay/submodule_request.hpp
@@ -214,6 +214,25 @@ public:
      */
     SubmoduleRequest& set_type(rtti_type type, type::input_map inputs);
 
+    /** @brief Check if the submodule satisfies a specific property type
+     *
+     *  @tparam T The property type that is being checked
+     *
+     * @throw std::runtime_error if a property type has not been set.
+     *        Strong throw guarantee.
+     */
+    template<typename T>
+    bool satisfies_property_type();
+
+    /** @brief Check by RTTI if the submodule satisfies a specific property type
+     *
+     *  @param type RTTI of the  property type that is being checked
+     *
+     * @throw std::runtime_error if a property type has not been set.
+     *        Strong throw guarantee.
+     */
+    bool satisfies_property_type(rtti_type type);
+
     /** @brief Sets the module that is to be used to satisfy the request
      *
      *  This function is designed to be called by the ModuleManager via the
@@ -433,9 +452,16 @@ auto& SubmoduleRequest::set_type() {
     return set_type(rtti_type(typeid(clean_t)), std::move(inputs));
 }
 
+template<typename T>
+bool SubmoduleRequest::satisfies_property_type() {
+    using clean_t = std::decay_t<T>;
+    rtti_type t_rtti(typeid(clean_t));
+    return satisfies_property_type(t_rtti);
+}
+
 template<typename property_type, typename... Args>
 auto SubmoduleRequest::run_as(Args&&... args) {
-    if(type() != std::type_index(typeid(property_type)))
+    if(type() != rtti_type(typeid(property_type)))
         throw std::invalid_argument("Wrong property type");
     return value().run_as<property_type>(std::forward<Args>(args)...);
 }

--- a/src/pluginplay/detail_/submodule_request_pimpl.hpp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.hpp
@@ -195,9 +195,6 @@ public:
      */
     bool ready() const;
 
-    template<typename T>
-    bool sastisfies_property_type();
-
     /** @brief Sets the property type the submodule must satisfy
      *
      *
@@ -210,6 +207,15 @@ public:
      *        Strong throw guarantee.
      */
     void set_type(rtti_type type, type::input_map inputs);
+
+    /** @brief Check if the submodule satisfies a specific property type
+     *
+     *  @param[in] type The RTTI of the property type
+     *
+     * @throw std::runtime_error if a property type has not been set.
+     *        Strong throw guarantee.
+     */
+    bool satisfies_property_type(rtti_type type);
 
     /** @brief Sets the module that is to be used to satisfy the request
      *

--- a/src/pluginplay/detail_/submodule_request_pimpl.hpp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.hpp
@@ -51,6 +51,8 @@ public:
 
     using submod_uuid_map = typename SubmoduleRequest::submod_uuid_map;
 
+    using rtti_type = typename SubmoduleRequest::rtti_type;
+
     /** @brief Makes an empty request.
      *
      *  The PIMPL resulting from this call will have no description, no type,
@@ -193,6 +195,9 @@ public:
      */
     bool ready() const;
 
+    template<typename T>
+    bool sastisfies_property_type();
+
     /** @brief Sets the property type the submodule must satisfy
      *
      *
@@ -204,7 +209,7 @@ public:
      * @throw std::runtime_error if the property type has already been set.
      *        Strong throw guarantee.
      */
-    void set_type(type::rtti type, type::input_map inputs);
+    void set_type(rtti_type type, type::input_map inputs);
 
     /** @brief Sets the module that is to be used to satisfy the request
      *
@@ -377,7 +382,7 @@ private:
     std::optional<type::description> m_desc_;
 
     /// RTTI of the property type the module must satisfy
-    std::optional<std::type_index> m_type_;
+    std::optional<rtti_type> m_type_;
 
     /// Inputs representative of those provided to the required property type
     type::input_map m_inputs_;

--- a/src/pluginplay/detail_/submodule_request_pimpl.ipp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.ipp
@@ -32,20 +32,17 @@ inline bool SubmoduleRequestPIMPL::ready() const {
     return has_type() && has_module() && m_module_->ready(m_inputs_);
 }
 
-template<typename T>
-bool SubmoduleRequestPIMPL::sastisfies_property_type() {
-    if(!has_type()) throw std::runtime_error("Property Type Not Set");
-    using clean_t = std::decay_t<T>;
-    rtti_type t_rtti(typeid(clean_t));
-    return (t_rtti == m_type_.value());
-}
-
 inline void SubmoduleRequestPIMPL::set_type(type::rtti type,
                                             type::input_map inputs) {
     if(has_module() && !value().property_types().count(type))
         throw std::runtime_error("Can't change type after setting module");
     m_type_.emplace(type);
     m_inputs_ = std::move(inputs);
+}
+
+bool SubmoduleRequestPIMPL::satisfies_property_type(rtti_type type) {
+    if(!has_type()) throw std::runtime_error("Property Type Not Set");
+    return (type == m_type_.value());
 }
 
 inline void SubmoduleRequestPIMPL::set_module(module_ptr ptr) {

--- a/src/pluginplay/detail_/submodule_request_pimpl.ipp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.ipp
@@ -33,8 +33,8 @@ inline bool SubmoduleRequestPIMPL::ready() const {
 }
 
 template<typename T>
-bool sastisfies_property_type() {
-    if(!has_type()) throw RuntimeError("Property Type Not Set");
+bool SubmoduleRequestPIMPL::sastisfies_property_type() {
+    if(!has_type()) throw std::runtime_error("Property Type Not Set");
     using clean_t = std::decay_t<T>;
     rtti_type t_rtti(typeid(clean_t));
     return (t_rtti == m_type_.value());

--- a/src/pluginplay/detail_/submodule_request_pimpl.ipp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.ipp
@@ -32,6 +32,14 @@ inline bool SubmoduleRequestPIMPL::ready() const {
     return has_type() && has_module() && m_module_->ready(m_inputs_);
 }
 
+template<typename T>
+bool sastisfies_property_type() {
+    if(!has_type()) throw RuntimeError("Property Type Not Set");
+    using clean_t = std::decay_t<T>;
+    rtti_type t_rtti(typeid(clean_t));
+    return (t_rtti == m_type_.value());
+}
+
 inline void SubmoduleRequestPIMPL::set_type(type::rtti type,
                                             type::input_map inputs) {
     if(has_module() && !value().property_types().count(type))

--- a/src/pluginplay/submodule_request.cpp
+++ b/src/pluginplay/submodule_request.cpp
@@ -55,6 +55,10 @@ SubmoduleRequest& SubmoduleRequest::set_type(rtti_type type,
     return *this;
 }
 
+bool SubmoduleRequest::satisfies_property_type(rtti_type type) {
+    return m_pimpl_->satisfies_property_type(type);
+}
+
 void SubmoduleRequest::change(module_ptr new_mod) {
     m_pimpl_->set_module(new_mod);
 }

--- a/src/python/export_module_manager.cpp
+++ b/src/python/export_module_manager.cpp
@@ -40,7 +40,8 @@ void export_module_manager(py_module_reference m) {
         [](ModuleManager& mm, std::string key,
            std::shared_ptr<PyModuleBase> p) { mm.add_module(key, p); },
         pybind11::keep_alive<1, 3>())
-      .def("at", static_cast<at_fxn>(&ModuleManager::at))
+      .def("at", static_cast<at_fxn>(&ModuleManager::at),
+           pybind11::return_value_policy::reference_internal)
       .def("copy_module", &ModuleManager::copy_module)
       .def("erase", &ModuleManager::erase)
       .def("rename_module", &ModuleManager::rename_module)

--- a/src/python/export_submodule_request.cpp
+++ b/src/python/export_submodule_request.cpp
@@ -28,6 +28,12 @@ void py_set_type(SubmoduleRequest& sr, pybind11::object pt) {
     sr.set_type(rtti, py_inputs.cast<type::input_map>());
 }
 
+bool py_satisfies_property_type(SubmoduleRequest& sr, pybind11::object pt) {
+    auto py_rtti = pt.attr("type")();
+    auto rtti    = py_rtti.cast<python::PyTypeInfo>().value();
+    return sr.satisfies_property_type(rtti);
+}
+
 auto py_sr_run_as(pybind11::object sr, pybind11::object pt,
                   pybind11::args args) {
     auto py_mod = sr.attr("value")();
@@ -45,6 +51,7 @@ void export_submodule_request(py_module_reference m) {
       .def("has_name", &SubmoduleRequest::has_name)
       .def("ready", &SubmoduleRequest::ready)
       .def("set_type", &py_set_type)
+      .def("satisfies_property_type", &py_satisfies_property_type)
       .def("set_description", &SubmoduleRequest::set_description)
       .def("submod_uuids", &SubmoduleRequest::submod_uuids)
       .def("uuid", &SubmoduleRequest::uuid)

--- a/tests/cxx/unit_tests/pluginplay/detail_/submodule_request_pimpl.cpp
+++ b/tests/cxx/unit_tests/pluginplay/detail_/submodule_request_pimpl.cpp
@@ -172,6 +172,17 @@ TEST_CASE("SubmoduleRequestPIMPL : set_type") {
     }
 }
 
+TEST_CASE("SubmoduleRequestPIMPL : satisfies_property_type") {
+    SubmoduleRequestPIMPL p;
+    pluginplay::type::input_map inputs;
+    p.set_type(null_pt_t, inputs);
+
+    SECTION("Does Satisfy") { REQUIRE(p.satisfies_property_type(null_pt_t)); }
+    SECTION("Doesn't Satisfy") {
+        REQUIRE_FALSE(p.satisfies_property_type(not_ready_pt_t));
+    }
+}
+
 TEST_CASE("SubmoduleRequestPIMPL : set_module") {
     SubmoduleRequestPIMPL p;
     auto mod = testing::make_module<testing::NullModule>();

--- a/tests/cxx/unit_tests/pluginplay/detail_/submodule_request_pimpl.cpp
+++ b/tests/cxx/unit_tests/pluginplay/detail_/submodule_request_pimpl.cpp
@@ -174,9 +174,12 @@ TEST_CASE("SubmoduleRequestPIMPL : set_type") {
 
 TEST_CASE("SubmoduleRequestPIMPL : satisfies_property_type") {
     SubmoduleRequestPIMPL p;
+    SECTION("Type Not Set") {
+        REQUIRE_THROWS_AS(p.satisfies_property_type(null_pt_t),
+                          std::runtime_error);
+    }
     pluginplay::type::input_map inputs;
     p.set_type(null_pt_t, inputs);
-
     SECTION("Does Satisfy") { REQUIRE(p.satisfies_property_type(null_pt_t)); }
     SECTION("Doesn't Satisfy") {
         REQUIRE_FALSE(p.satisfies_property_type(not_ready_pt_t));

--- a/tests/cxx/unit_tests/pluginplay/submodule_request.cpp
+++ b/tests/cxx/unit_tests/pluginplay/submodule_request.cpp
@@ -130,8 +130,11 @@ TEST_CASE("SubmoduleRequest : set_type") {
 
 TEST_CASE("SubmoduleRequest : satisfies_property_type") {
     SubmoduleRequest p;
+    SECTION("Type Not Set") {
+        REQUIRE_THROWS_AS(p.satisfies_property_type<testing::NullPT>(),
+                          std::runtime_error);
+    }
     p.set_type<testing::NullPT>();
-
     SECTION("Does Satisfy") {
         REQUIRE(p.satisfies_property_type<testing::NullPT>());
     }

--- a/tests/cxx/unit_tests/pluginplay/submodule_request.cpp
+++ b/tests/cxx/unit_tests/pluginplay/submodule_request.cpp
@@ -128,6 +128,18 @@ TEST_CASE("SubmoduleRequest : set_type") {
     }
 }
 
+TEST_CASE("SubmoduleRequest : satisfies_property_type") {
+    SubmoduleRequest p;
+    p.set_type<testing::NullPT>();
+
+    SECTION("Does Satisfy") {
+        REQUIRE(p.satisfies_property_type<testing::NullPT>());
+    }
+    SECTION("Doesn't Satisfy") {
+        REQUIRE_FALSE(p.satisfies_property_type<testing::OneIn>());
+    }
+}
+
 TEST_CASE("SubmoduleRequest : change") {
     SubmoduleRequest r;
     auto mod = testing::make_module<testing::NullModule>();

--- a/tests/python/unit_tests/test_module_manager.py
+++ b/tests/python/unit_tests/test_module_manager.py
@@ -57,6 +57,12 @@ class TestModuleManager(unittest.TestCase):
         # Can actually get a module
         self.assertNotEqual(self.has_mods.at('C++ no PT'), None)
 
+        # at returns reference
+        self.assertTrue(self.has_mods.at('C++ no PT').is_memoizable())
+        mod = self.has_mods.at('C++ no PT')
+        mod.turn_off_memoization()
+        self.assertFalse(self.has_mods.at('C++ no PT').is_memoizable())
+
     def test_copy_module(self):
         # Throws if there's no implementation
         self.assertRaises(Exception, self.defaulted.copy_module, 'foo', 'bar')
@@ -92,13 +98,11 @@ class TestModuleManager(unittest.TestCase):
 
     def test_rename_module(self):
         # Throws if there's not implementation
-        self.assertRaises(Exception, self.defaulted.rename_module, 'foo',
-                          'bar')
+        self.assertRaises(Exception, self.defaulted.rename_module, 'foo', 'bar')
 
         # Throws if from is not a valid key
         has_mods = self.has_mods
-        self.assertRaises(Exception, has_mods.rename_module, 'not a key',
-                          'bar')
+        self.assertRaises(Exception, has_mods.rename_module, 'not a key', 'bar')
 
         # Throws if to key is in use
         from_key = 'C++ no PT'

--- a/tests/python/unit_tests/test_submodule_request.py
+++ b/tests/python/unit_tests/test_submodule_request.py
@@ -57,6 +57,14 @@ class TestSubmoduleRequest(unittest.TestCase):
         self.defaulted.set_type(test_pp.NullPT())
         self.assertTrue(self.defaulted.has_type())
 
+    def test_satisfies_property_type(self):
+        pt1 = test_pp.NullPT()
+        pt2 = test_pp.OneIn()
+        self.assertRaises(RuntimeError, self.defaulted.satisfies_property_type, pt1)
+        self.defaulted.set_type(pt1)
+        self.assertTrue(self.defaulted.satisfies_property_type(pt1))
+        self.assertFalse(self.defaulted.satisfies_property_type(pt2))
+
     def test_set_description(self):
         self.assertFalse(self.defaulted.has_description())
         self.defaulted.set_description("Hello World!")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Closes #197

**Description**
Adds functions to the `SubmoduleRequest` and its `PIMPL` to check if the request satisfies a particular property type. Additionally, patches the python bindings for `ModuleManager::at` so that the returned values are references.