### PR TITLE
exposes runtime to Python

### DIFF
--- a/src/pluginplay/detail_/module_manager_pimpl.hpp
+++ b/src/pluginplay/detail_/module_manager_pimpl.hpp
@@ -243,7 +243,7 @@ struct ModuleManagerPIMPL {
 
     void set_runtime(runtime_ptr runtime) noexcept { m_runtime_ = runtime; }
 
-    runtime_type& get_runtime() const { return *m_runtime_.get(); }
+    runtime_type& get_runtime() const { return *m_runtime_; }
 
     ModuleManager::key_container_type keys() const {
         ModuleManager::key_container_type keys;

--- a/src/python/export_module_manager.cpp
+++ b/src/python/export_module_manager.cpp
@@ -16,6 +16,7 @@
 
 #include "export_pluginplay.hpp"
 #include "py_module_base.hpp"
+#include <parallelzone/parallelzone.hpp>
 #include <pluginplay/any/any.hpp>
 #include <pluginplay/module_manager.hpp>
 #include <pluginplay/python/python_wrapper.hpp>
@@ -24,7 +25,8 @@
 namespace pluginplay {
 
 void export_module_manager(py_module_reference m) {
-    using at_fxn = Module& (ModuleManager::*)(const type::key&);
+    using at_fxn       = Module& (ModuleManager::*)(const type::key&);
+    using runtime_type = typename ModuleManager::runtime_type;
 
     using py_obj = pybind11::object;
     using python::PythonWrapper;
@@ -54,8 +56,12 @@ void export_module_manager(py_module_reference m) {
            [](py_obj self, py_obj pt, py_obj key, pybind11::args args) {
                return self.attr("at")(key).attr("run_as")(pt, *args);
            })
+      .def("set_runtime",
+           [](ModuleManager& mm, runtime_type rv) {
+               mm.set_runtime(std::make_shared<runtime_type>(std::move(rv)));
+           })
       .def("get_runtime", &ModuleManager::get_runtime,
-           pybind11::keep_alive<0, 1>())
+           pybind11::return_value_policy::reference_internal)
       .def("keys", &ModuleManager::keys)
       .def("__getitem__", [](ModuleManager& self, const type::key& key) {
           return self.at(key);

--- a/src/python/export_module_manager.cpp
+++ b/src/python/export_module_manager.cpp
@@ -54,6 +54,8 @@ void export_module_manager(py_module_reference m) {
            [](py_obj self, py_obj pt, py_obj key, pybind11::args args) {
                return self.attr("at")(key).attr("run_as")(pt, *args);
            })
+      .def("get_runtime", &ModuleManager::get_runtime,
+           pybind11::keep_alive<0, 1>())
       .def("keys", &ModuleManager::keys)
       .def("__getitem__", [](ModuleManager& self, const type::key& key) {
           return self.at(key);

--- a/tests/cxx/unit_tests/pluginplay/module_manager.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module_manager.cpp
@@ -51,6 +51,16 @@ TEST_CASE("ModuleManager") {
         REQUIRE(count == mm.size());
     }
 
+    SECTION("set_runtime") {
+        auto prv = std::make_shared<parallelzone::runtime::RuntimeView>();
+        mm.set_runtime(prv);
+        REQUIRE(&mm.get_runtime() == prv.get());
+    }
+
+    SECTION("get_runtime") {
+        REQUIRE(mm.get_runtime() == parallelzone::runtime::RuntimeView());
+    }
+
     SECTION("keys") {
         using mod_t = testing::NoPTModule; // Type of the Module we're adding
 

--- a/tests/python/unit_tests/test_module_manager.py
+++ b/tests/python/unit_tests/test_module_manager.py
@@ -203,6 +203,9 @@ class TestModuleManager(unittest.TestCase):
         self.assertTrue(module_with_description.has_description())
         self.assertNotEqual(self.has_mods['C++ no PT'], None)
 
+    def test_get_runtime(self):
+        self.assertIsNone(self.has_mods.get_runtime())
+
     def test_keys(self):
         self.assertEqual(len(self.defaulted.keys()), self.defaulted.size())
         self.assertEqual(len(self.has_mods.keys()), self.has_mods.size())

--- a/tests/python/unit_tests/test_module_manager.py
+++ b/tests/python/unit_tests/test_module_manager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pluginplay as pp
+import parallelzone
 import py_test_pluginplay as test_pp
 import unittest
 
@@ -203,8 +204,13 @@ class TestModuleManager(unittest.TestCase):
         self.assertTrue(module_with_description.has_description())
         self.assertNotEqual(self.has_mods['C++ no PT'], None)
 
+    def test_set_runtime(self):
+        new_rv = parallelzone.runtime.RuntimeView()
+        self.defaulted.set_runtime(new_rv)
+        self.assertEqual(self.defaulted.get_runtime(), new_rv)
+
     def test_get_runtime(self):
-        self.assertIsNone(self.has_mods.get_runtime())
+        self.assertTrue(self.has_mods.get_runtime())
 
     def test_keys(self):
         self.assertEqual(len(self.defaulted.keys()), self.defaulted.size())

--- a/tests/python/unit_tests/test_pluginplay.cpp
+++ b/tests/python/unit_tests/test_pluginplay.cpp
@@ -50,7 +50,7 @@ PYBIND11_MODULE(py_test_pluginplay, m) {
     EXPORT_PROPERTY_TYPE(OneInOneOut, m);
 
     m.def("get_mm", []() {
-        pluginplay::ModuleManager mm(nullptr);
+        pluginplay::ModuleManager mm;
         mm.add_module<NoPTModule>("C++ no PT");
         mm.add_module<NullModule>("C++ Null PT");
         mm.add_module<DescModule>("C++ with description");


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
None.

**Description**
The `RuntimeView` associated with the `ModuleManager` was not being exposed. This fixes that.

**TODOs**
None. R2g.
