### PR TITLE
Print input descriptions verbatim to avoid malformated Sphinx

### DIFF
--- a/src/pluginplay/printing/detail_/print_inputs.cpp
+++ b/src/pluginplay/printing/detail_/print_inputs.cpp
@@ -44,7 +44,9 @@ std::string input_quick_ref_table(const type::input_map& inputs) {
     table.set_border_style(NWX_RST_STYLE);
 
     // Add the header
-    table << fort::header << "Key" << "Default" << "Description" << fort::endr;
+    table << fort::header << "Key"
+          << "Default"
+          << "Description" << fort::endr;
 
     // Add all data rows
     for(const auto& [name, value] : inputs) {

--- a/src/pluginplay/printing/detail_/print_inputs.cpp
+++ b/src/pluginplay/printing/detail_/print_inputs.cpp
@@ -44,9 +44,7 @@ std::string input_quick_ref_table(const type::input_map& inputs) {
     table.set_border_style(NWX_RST_STYLE);
 
     // Add the header
-    table << fort::header << "Key"
-          << "Default"
-          << "Description" << fort::endr;
+    table << fort::header << "Key" << "Default" << "Description" << fort::endr;
 
     // Add all data rows
     for(const auto& [name, value] : inputs) {
@@ -77,8 +75,9 @@ reSTPrinter& input_full_list(reSTPrinter& p, const type::input_map& inputs) {
     for(const auto& [name, input] : inputs) {
         p.start_section(name);
         p << "\n";
-        p << std::string("- Description : ") +
-               (input.has_description() ? input.description() : "N/A") + "\n";
+        p.print_verbatim(
+          std::string("- Description : ") +
+          (input.has_description() ? input.description() : "N/A") + "\n");
         p << std::string("- Default Value : ") +
                (input.has_value() ? input.str() : "N/A") + "\n";
         p << std::string("- Optional? : ") +


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Long input descriptions can get wrapped to a new line in the docs source, which interferes with the bulleted list. Ideally, the `reSTPrinter` should probably be able to infer necessary indentations, but that's a larger issue. For now, this just prints the descriptions verbatim to avoid the breakage.