### PR TITLE
Exposes ModuleBase's RuntimeView Object to Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ nwx_cxx_api_docs("README.md" "${project_inc_dir}" "${project_src_dir}")
 ### Options ###
 cmaize_option_list(
     BUILD_TESTING OFF "Should we build unit tests?"
-    BUILD_PYBIND11_PYBINDINGS OFF "Build Pybind11 Python bindings?"
+    BUILD_PYBIND11_PYBINDINGS ON "Build Pybind11 Python bindings?"
     BUILD_ROCKSDB OFF "Enable RocksDB backend of the cache?"
 )
 
@@ -152,10 +152,6 @@ if("${BUILD_TESTING}")
 
     ### Python Tests ###
     set(python_test_dir "${CMAKE_CURRENT_LIST_DIR}/tests/python")
-    cmaize_find_or_build_dependency(
-        tox
-        PACKAGE_MANAGER pip
-    )
 
     # In the python tests we will pass Python into PluginPlay, we will then
     # need to know that C++ can handle those Python types. To this end we
@@ -166,11 +162,11 @@ if("${BUILD_TESTING}")
         INSTALL OFF
         SOURCE_DIR "${python_test_dir}/unit_tests"
         INCLUDE_DIRS "${project_inc_dir}"
-        DEPENDS ${PROJECT_NAME} tox
+        DEPENDS ${PROJECT_NAME}
     )
 
-    nwx_tox_test(
-        py_pluginplay ${python_test_dir}/unit_tests
+    nwx_pybind11_tests(
+        py_pluginplay ${python_test_dir}/unit_tests/test_pluginplay.py
         SUBMODULES parallelzone
     )
 

--- a/src/python/module/export_module_base.cpp
+++ b/src/python/module/export_module_base.cpp
@@ -40,6 +40,7 @@ void export_module_base(py_module_reference m) {
       .def("property_types", &ModuleBase::property_types)
       .def("get_desc", &ModuleBase::get_desc)
       .def("citations", &ModuleBase::citations)
+      .def("get_runtime", &ModuleBase::get_runtime)
       //   //.def("set_cache", &ModuleBase::set_cache)
       //   .def("get_cache", &ModuleBase::get_cache)
       //   .def("reset_internal_cache", &ModuleBase::reset_internal_cache)

--- a/tests/python/unit_tests/module/test_module_base.py
+++ b/tests/python/unit_tests/module/test_module_base.py
@@ -34,6 +34,7 @@ class APythonModule(pp.ModuleBase):
         i0, = pt.unwrap_inputs(inputs)
         i1 = inputs["An extra input"].value()
 
+        assert (self.get_runtime() == pz.runtime.RuntimeView())
         r0 = submods["A submodule"].run_as(pt, i0 + i1)
 
         rv = self.results()
@@ -52,10 +53,6 @@ class TestModuleBase(unittest.TestCase):
         self.mm.change_input(self.mod_key, 'An extra input', 2)
         r = self.mm.run_as(test_pp.OneInOneOut(), self.mod_key, 1)
         self.assertEqual(r, 3)
-
-    def test_get_runtime(self):
-        mod = self.mm.at(self.mod_key)
-        self.assertEqual(mod.get_runtime(), pz.runtime.RuntimeView())
 
     def setUp(self):
         self.defaulted = pp.ModuleBase()

--- a/tests/python/unit_tests/module/test_module_base.py
+++ b/tests/python/unit_tests/module/test_module_base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pluginplay as pp
+import parallelzone as pz
 import py_test_pluginplay as test_pp
 import unittest
 
@@ -51,6 +52,10 @@ class TestModuleBase(unittest.TestCase):
         self.mm.change_input(self.mod_key, 'An extra input', 2)
         r = self.mm.run_as(test_pp.OneInOneOut(), self.mod_key, 1)
         self.assertEqual(r, 3)
+
+    def test_get_runtime(self):
+        mod = self.mm.at(self.mod_key)
+        self.assertEqual(mod.get_runtime(), pz.runtime.RuntimeView())
 
     def setUp(self):
         self.defaulted = pp.ModuleBase()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Title.

**TODOs**
For some reason the test fails locally claiming it can't find ParallelZone, if it fails on GitHub too I guess I actually need to address that error...