### PR TITLE
Fix incorrect PyBind11 headers target reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if("${BUILD_PYBIND11_PYBINDINGS}")
     nwx_find_pybind11()
     list(
         APPEND pluginplay_depends
-        pybind11_headers pybind11::embed Python::Python
+        pybind11::headers pybind11::embed Python::Python
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ cmaize_find_optional_dependency(
 set(pluginplay_depends utilities parallelzone libfort Boost::boost RocksDB)
 
 # As of 1.0.0 CMaize does not support multiple build or find targets. This will
-# be fixed in a future feature release. For now we handle the
+# be fixed in a future feature release. For now we handle the exposed CMake
+# targets separately instead of a CMaize target
 include(nwx_pybind11)
 if("${BUILD_PYBIND11_PYBINDINGS}")
     nwx_find_pybind11()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The current name used to reference the PyBind11 headers target (`pybind11_headers`) only exists if PyBind11 is built with your project. If it is already installed, the exported target is instead `pybind11::headers`. During the build, `pybind11_headers` is aliased to `pybind11::headers` ([here](https://github.com/pybind/pybind11/blob/master/CMakeLists.txt#L279)), so using `pybind11::headers` exclusively should work in both scenarios.

**TODOs**
- [x] ParallelZone may need to be updated first for this to pass.
