### PR TITLE
`PythonWrapper::unwrap` Patch

### DIFF
--- a/include/pluginplay/python/python_wrapper.hpp
+++ b/include/pluginplay/python/python_wrapper.hpp
@@ -18,7 +18,6 @@
 #include <boost/any.hpp>
 #include <stdexcept>
 #ifdef BUILD_PYBIND11
-#include <iostream>
 #include <memory>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/include/pluginplay/python/python_wrapper.hpp
+++ b/include/pluginplay/python/python_wrapper.hpp
@@ -18,6 +18,7 @@
 #include <boost/any.hpp>
 #include <stdexcept>
 #ifdef BUILD_PYBIND11
+#include <iostream>
 #include <memory>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -305,7 +306,7 @@ T PythonWrapper::unwrap() {
     }
     // User wants the converted C++ value by reference or const reference
     else {
-        if(m_buffer_.empty()) {
+        if(m_buffer_.empty() || m_buffer_.type() != typeid(clean_type)) {
             auto cxx_value = py_value.cast<clean_type>();
             m_buffer_      = std::move(cxx_value);
         }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
When unwrapping an object wrapped by a `PythonWrapper` to a reference, the recast python object is copied into an `any` buffer. This buffer persists on the `PythonWrapper` and is checked on successive calls to `unwrap` to avoid repetitious effort. If the previous type being cast to isn't lossless when copied (e.g. casting an `int` to `bool`), the value stored in the buffer isn't sufficient and the underlying object needs to be reinterpreted again. This patch checks that the stored type is consistent with the requested return type, and triggers the recasting if not.