### PR TITLE
Clang Type Comparison

### DIFF
--- a/src/pluginplay/detail_/submodule_request_pimpl.ipp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.ipp
@@ -53,7 +53,8 @@ inline void SubmoduleRequestPIMPL::set_module(module_ptr ptr) {
     // Work around for libc++ typeid inconsistency in Python
     if(!suitable) {
         for(const auto& property_type_info : ptr->property_types()) {
-            if(type().name() == property_type_info.name()) {
+            if(type().name() == property_type_info.name() ||
+               std::strcmp(type().name(), property_type_info.name()) == 0) {
                 suitable = true;
                 break;
             }

--- a/src/pluginplay/detail_/submodule_request_pimpl.ipp
+++ b/src/pluginplay/detail_/submodule_request_pimpl.ipp
@@ -48,11 +48,24 @@ bool SubmoduleRequestPIMPL::satisfies_property_type(rtti_type type) {
 inline void SubmoduleRequestPIMPL::set_module(module_ptr ptr) {
     if(!ptr) throw std::runtime_error("Pointer does not contain a module");
     // Type will check that a property type was set
-    if(ptr->property_types().count(type()) == 0) {
+    bool suitable = (ptr->property_types().count(type()) > 0);
+
+    // Work around for libc++ typeid inconsistency in Python
+    if(!suitable) {
+        for(const auto& property_type_info : ptr->property_types()) {
+            if(type().name() == property_type_info.name()) {
+                suitable = true;
+                break;
+            }
+        }
+    }
+
+    if(!suitable) {
         std::string msg("Module does not satisfy property type: ");
         msg += utilities::printing::Demangler::demangle(type());
         throw std::runtime_error(msg);
     }
+
     m_module_ = ptr;
 }
 

--- a/src/pluginplay/module/module.cpp
+++ b/src/pluginplay/module/module.cpp
@@ -138,7 +138,9 @@ void Module::check_property_type_(type::rtti prop_type) {
 
     // Work around for libc++ typeid inconsistency in Python
     for(const auto& m_prop_type : property_types()) {
-        if(prop_type.name() == m_prop_type.name()) return;
+        if(prop_type.name() == m_prop_type.name() ||
+           std::strcmp(prop_type.name(), m_prop_type.name()) == 0)
+            return;
     }
 
     std::string msg = "Module does not satisfy property type ";

--- a/src/pluginplay/module/module.cpp
+++ b/src/pluginplay/module/module.cpp
@@ -135,6 +135,12 @@ void Module::add_property_type_(pluginplay::type::rtti prop_type) {
 
 void Module::check_property_type_(type::rtti prop_type) {
     if(property_types().count(prop_type)) return;
+
+    // Work around for libc++ typeid inconsistency in Python
+    for(const auto& m_prop_type : property_types()) {
+        if(prop_type.name() == m_prop_type.name()) return;
+    }
+
     std::string msg = "Module does not satisfy property type ";
     msg += utilities::printing::Demangler::demangle(prop_type);
     throw std::runtime_error(msg);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
The combination of Python and Libc++ (possibly other STL implementations as well) results in some `type_info` comparisons that should be `true` and evaluating as `false`, which trips up some property type checks for setting submodules. The changes in this PR add additional checks on property type equality based on type name, to catch the improper failures.